### PR TITLE
add etc directory to init

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,13 @@ class vsftpd (
     hasstatus => true,
   }
 
+  file { '/etc/vsftpd':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
   file { '/etc/vsftpd/vsftpd.conf':
     require => Package['vsftpd'],
     content => template('vsftpd/vsftpd.conf.erb'),


### PR DESCRIPTION
Config file has a dependency for /etc/vsftpd, I've added the directory creation to the init manifest.
