### PR TITLE
Added support for 'userlist_deny' option.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class vsftpd (
   $listen_port             = undef,
   $pam_service_name        = 'vsftpd',
   $userlist_enable         = 'YES',
+  $userlist_deny           = 'YES',
   $tcp_wrappers            = 'YES',
   $hide_file               = undef,
   $hide_ids                = 'NO',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class vsftpd (
   $listen_port             = undef,
   $pam_service_name        = 'vsftpd',
   $userlist_enable         = 'YES',
-  $userlist_deny           = 'YES',
+  $userlist_deny           = undef,
   $tcp_wrappers            = 'YES',
   $hide_file               = undef,
   $hide_ids                = 'NO',

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -170,6 +170,7 @@ listen_port=<%= @listen_port %>
 
 pam_service_name=<%= @pam_service_name %>
 userlist_enable=<%= @userlist_enable %>
+userlist_deny=<%= @userlist_deny %>
 tcp_wrappers=<%= @tcp_wrappers %>
 <% if @hide_file -%>
 hide_file=<%= @hide_file %>

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -170,7 +170,9 @@ listen_port=<%= @listen_port %>
 
 pam_service_name=<%= @pam_service_name %>
 userlist_enable=<%= @userlist_enable %>
+<% if @userlist_deny -%>
 userlist_deny=<%= @userlist_deny %>
+<% end -%>
 tcp_wrappers=<%= @tcp_wrappers %>
 <% if @hide_file -%>
 hide_file=<%= @hide_file %>


### PR DESCRIPTION
Hi,

I added support for the _userlist_deny_ option of vsftpd.

Changes:
- Added `userlist_deny` option to **vsftpd.conf** template.
- Added `userlist_deny` parameter to vsftpd class. The default value for the parameter is `YES`, as it is in vsftpd (so this change shouldn't affect existing installations).

I'd appreciate it if a new version with this change can be submitted to Puppet Forge.

Regards,

Dennis
