### PR TITLE
Added allow_writeable_chroot config option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,7 @@ class vsftpd (
   $ftp_username            = undef,
   $banner_file             = undef,
   $directives              = {},
+  $allow_writeable_chroot  = undef,
 ) inherits ::vsftpd::params {
 
   package { $package_name: ensure => installed }

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -201,3 +201,6 @@ banner_file=<%= @banner_file %>
 <% @directives.sort_by {|key,value| key}.each do |key,value| -%>
 <%= key %>=<%= value %>
 <% end -%>
+<% if @allow_writeable_chroot -%>
+allow_writeable_chroot=<%= @allow_writeable_chroot %>
+<% end -%>


### PR DESCRIPTION
See the following issues:
http://askubuntu.com/questions/128180/vsftpd-stopped-working-after-update
http://blog.thefrontiergroup.com.au/2012/10/making-vsftpd-with-chrooted-users-work-again/

Adding the 'allow_writeable_chroot' solves them (for vsftpd > v3.0)
