### PR TITLE
Add SLES to params.pp for the default confdir.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class vsftpd::params {
       $confdir = '/etc/vsftpd'
     }
     'Debian',
+    'SLES',
     'Ubuntu': {
       $confdir = '/etc'
     }


### PR DESCRIPTION
This adds a default of the confdir parameter for Suse SLES to params.pp in order to not have to specify it as parameter.
