### PR TITLE
seccomp_sandbox config parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,7 @@ class vsftpd (
   $ftp_username            = undef,
   $banner_file             = undef,
   $allow_writeable_chroot  = undef,
+  $seccomp_sandbox         = undef,
   $directives              = {},
 ) inherits ::vsftpd::params {
 

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -204,3 +204,6 @@ allow_writeable_chroot=<%= @allow_writeable_chroot %>
 <% @directives.reject {|key,value| value == :undef}.sort_by {|key,value| key}.each do |key,value| -%>
 <%= key %>=<%= value %>
 <% end -%>
+<% if @seccomp_sandbox -%>
+seccomp_sandbox=<%= @seccomp_sandbox %>
+<% end -%>


### PR DESCRIPTION
Allowing the seccomp_sandbox parameter fixes the following problem: http://superuser.com/questions/908024/vsftpd-500-oops-prctl-pr-set-seccomp-failed

It appears in CentOS too, not only Ubuntu.
